### PR TITLE
feat: add self-hosted Node.js server with Docker build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ obj
 
 .env.local
 .DS_Store
+
+/celeste-wasm-server
+/server/cache

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,158 @@
+# Multi-stage build for celeste-wasm self-hosted server package
+#
+# This Dockerfile builds the frontend, bundles game assets from celeste-wasm.tar,
+# and produces a lightweight Node.js image that serves everything.
+#
+# Usage:
+#   # 1. Optionally prepare docker-assets/ with Celeste.exe for auto-patching
+#   # 2. Ensure celeste-wasm.tar is at the project root
+#   # 3. Build:
+#   docker build --platform linux/amd64 -f Dockerfile.server -t celeste-wasm-server .
+#   # 4a. Run as Docker container:
+#   docker run -p 8080:8080 celeste-wasm-server
+#   # 4b. OR extract the package to run natively with Node.js:
+#   docker create --name tmp celeste-wasm-server
+#   docker cp tmp:/app celeste-wasm-server
+#   docker rm tmp
+#   cd celeste-wasm-server && node server.mjs
+
+# ---------------------------------------------------------------------------
+# Stage 1: Build the frontend (dotnet + emsdk + pnpm)
+# ---------------------------------------------------------------------------
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/sdk:9.0 AS dotnet-build
+
+RUN set -eux; \
+    for i in 1 2 3; do \
+        apt-get update && break || (echo "Retry $i of 3..." && sleep 10); \
+    done; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    git \
+    wget \
+    python3 \
+    build-essential \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo "Skipping mono-devel - MonoMod uses Mono.Cecil NuGet package"
+
+# Install Node.js
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Pin pnpm to v9 — pnpm 10+ blocks build scripts by default and fails on esbuild
+RUN npm install -g pnpm@9
+
+WORKDIR /build
+
+# Copy package files first for better layer caching
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install
+
+# Copy project files
+COPY . .
+
+# docker-assets/ for optional Celeste.exe patching
+COPY docker-assets /tmp/docker-assets/
+
+# Install .NET workloads
+RUN cd loader && dotnet workload restore && cd ..
+
+# Clone dependencies first (NLua, FNA, MonoMod, emsdk, etc.)
+RUN make deps
+
+# Fix NLua signing on Linux — must run AFTER make deps clones NLua
+# The _SignAssembly target calls 'sn' which doesn't exist on Linux;
+# rewrite the file to disable signing entirely
+RUN if [ -f NLua/build/targets/NLua.Sign.targets ]; then \
+        printf '<?xml version="1.0" encoding="utf-8"?>\n<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">\n    <PropertyGroup>\n        <SignAssembly>true</SignAssembly>\n        <PublicSign>true</PublicSign>\n        <KeyFileName Condition=" '\''$(KeyFileName)'\'' == '\'''\'' ">NLua.snk</KeyFileName>\n        <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\\..\\..\\$(KeyFileName)</AssemblyOriginatorKeyFile>\n    </PropertyGroup>\n</Project>\n' \
+            > NLua/build/targets/NLua.Sign.targets && \
+        echo "Replaced NLua.Sign.targets (disabled _SignAssembly target)"; \
+    fi
+
+# Build the frontend (deps already installed, this runs build + pnpm build)
+RUN make publish
+
+# Patch Celeste.exe if Celeste.exe is in docker-assets/ (same logic as existing Dockerfile)
+RUN if [ -f "/tmp/docker-assets/Celeste.exe" ] && [ ! -f "/tmp/docker-assets/CustomCeleste.dll" ]; then \
+        echo "Building patcher tool..."; \
+        cd build-patcher && \
+        dotnet build -c Release -o /tmp/patcher-tool || (echo "Patcher build failed, will patch at runtime" && exit 0); \
+        echo "Patching Celeste.exe to create CustomCeleste.dll..."; \
+        mkdir -p /tmp/patch-work/libsdl/Celeste/Everest /tmp/patch-work/bin; \
+        cp /tmp/docker-assets/Celeste.exe /tmp/patch-work/libsdl/Celeste.exe; \
+        if [ -f "loader/bin/Release/net9.0/publish/Celeste.Wasm.mm.dll" ]; then \
+            cp loader/bin/Release/net9.0/publish/Celeste.Wasm.mm.dll /tmp/patch-work/bin/; \
+        elif [ -f "patcher/bin/Release/net9.0/Celeste.Wasm.mm.dll" ]; then \
+            cp patcher/bin/Release/net9.0/Celeste.Wasm.mm.dll /tmp/patch-work/bin/; \
+        elif [ -f "patcher/bin/Release/net9.0/publish/Celeste.Wasm.mm.dll" ]; then \
+            cp patcher/bin/Release/net9.0/publish/Celeste.Wasm.mm.dll /tmp/patch-work/bin/; \
+        else \
+            echo "Warning: Celeste.Wasm.mm.dll not found, skipping patching"; \
+            exit 0; \
+        fi; \
+        /tmp/patcher-tool/BuildPatcher \
+            /tmp/patch-work/libsdl/Celeste.exe \
+            /tmp/docker-assets/CustomCeleste.dll \
+            false || \
+        (echo "Note: Automatic patching failed, Celeste.exe will be patched at runtime"); \
+    else \
+        echo "Celeste.exe not found or CustomCeleste.dll already exists, skipping patching"; \
+    fi
+
+# Stage the game executables into a known location for the assembler
+RUN mkdir -p /tmp/game-output && \
+    if [ -f /tmp/docker-assets/CustomCeleste.dll ]; then \
+        cp /tmp/docker-assets/CustomCeleste.dll /tmp/game-output/; \
+    fi && \
+    if [ -f /tmp/docker-assets/Celeste.exe ]; then \
+        cp /tmp/docker-assets/Celeste.exe /tmp/game-output/; \
+    fi && \
+    ls -la /tmp/game-output/ || true
+
+# ---------------------------------------------------------------------------
+# Stage 2: Assemble the server package
+# ---------------------------------------------------------------------------
+FROM node:22-slim AS assembler
+
+WORKDIR /package
+
+# Copy the built frontend from stage 1
+COPY --from=dotnet-build /build/frontend/dist ./dist
+
+# Copy the server script
+COPY server/server.mjs ./server.mjs
+
+# Copy celeste-wasm.tar directly from build context
+COPY celeste-wasm.tar ./celeste-wasm.tar
+
+# Copy game executables from the dotnet-build stage (may be empty)
+COPY --from=dotnet-build /tmp/game-output/ /tmp/game-files/
+
+# Bundle patched game files into dist/ so they're available without tar extraction
+RUN if [ -f /tmp/game-files/CustomCeleste.dll ]; then \
+        cp /tmp/game-files/CustomCeleste.dll ./dist/CustomCeleste.dll && \
+        echo "Bundled patched CustomCeleste.dll into dist/"; \
+    elif [ -f /tmp/game-files/Celeste.exe ]; then \
+        cp /tmp/game-files/Celeste.exe ./dist/Celeste.exe && \
+        echo "Bundled Celeste.exe into dist/"; \
+    else \
+        echo "No game executables to bundle (they will be served from tar on first run)"; \
+    fi && \
+    rm -rf /tmp/game-files
+
+# ---------------------------------------------------------------------------
+# Stage 3: Final lightweight runtime image
+# ---------------------------------------------------------------------------
+FROM node:22-slim
+
+WORKDIR /app
+
+COPY --from=assembler /package ./
+
+EXPOSE 8080
+
+CMD ["node", "server.mjs", "--no-open", "--port", "8080", "--host", "0.0.0.0"]

--- a/Makefile
+++ b/Makefile
@@ -64,5 +64,15 @@ serve: build
 publish: build
 	pnpm build
 
+# Docker-based server build (no local dotnet/emsdk needed)
+docker-server:
+	@bash scripts/docker-build-server.sh
 
-.PHONY: clean build serve publish
+docker-server-extract:
+	@bash scripts/docker-build-server.sh --extract
+
+docker-server-build:
+	@bash scripts/docker-build-server.sh --build-only
+
+
+.PHONY: clean build serve publish docker-server docker-server-extract docker-server-build

--- a/scripts/build-server-package.sh
+++ b/scripts/build-server-package.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Build the celeste-wasm self-hosted server package
+#
+# Prerequisites:
+#   - frontend/dist/ must exist (run "make publish" first)
+#   - celeste-wasm.tar must exist in the project root
+#
+# Output: celeste-wasm-server/ directory ready to distribute
+#   Run with: cd celeste-wasm-server && node server.mjs
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DIST_DIR="$PROJECT_ROOT/frontend/dist"
+TAR_FILE="$PROJECT_ROOT/celeste-wasm.tar"
+SERVER_SCRIPT="$PROJECT_ROOT/server/server.mjs"
+OUTPUT_DIR="$PROJECT_ROOT/celeste-wasm-server"
+
+echo ""
+echo "  Building celeste-wasm server package"
+echo "  -------------------------------------"
+echo ""
+
+# Validate prerequisites
+if [ ! -d "$DIST_DIR" ] || [ ! -f "$DIST_DIR/index.html" ]; then
+    echo "  Error: frontend/dist/ not found or empty."
+    echo "  Run 'make publish' first to build the frontend."
+    exit 1
+fi
+
+if [ ! -f "$TAR_FILE" ]; then
+    echo "  Error: celeste-wasm.tar not found at project root."
+    echo "  Ensure the game assets tar file exists."
+    exit 1
+fi
+
+if [ ! -f "$SERVER_SCRIPT" ]; then
+    echo "  Error: server/server.mjs not found."
+    exit 1
+fi
+
+# Clean and create output directory
+echo "  Cleaning output directory..."
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+# Copy built frontend
+echo "  Copying frontend dist/..."
+cp -r "$DIST_DIR" "$OUTPUT_DIR/dist"
+
+# Copy game assets tar
+echo "  Copying celeste-wasm.tar (~1.3GB, this may take a moment)..."
+cp "$TAR_FILE" "$OUTPUT_DIR/celeste-wasm.tar"
+
+# Copy server script
+echo "  Copying server.mjs..."
+cp "$SERVER_SCRIPT" "$OUTPUT_DIR/server.mjs"
+chmod +x "$OUTPUT_DIR/server.mjs"
+
+echo ""
+echo "  Package ready at: celeste-wasm-server/"
+echo ""
+echo "  To run:"
+echo "    cd celeste-wasm-server"
+echo "    node server.mjs"
+echo ""
+echo "  Options:"
+echo "    node server.mjs --port 9000       # custom port"
+echo "    node server.mjs --no-open         # don't auto-open browser"
+echo "    node server.mjs --help            # all options"
+echo ""

--- a/scripts/docker-build-server.sh
+++ b/scripts/docker-build-server.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Build the celeste-wasm self-hosted server package via Docker
+#
+# This script:
+#   1. Builds the frontend inside Docker (dotnet + emsdk + pnpm)
+#   2. Assembles a server package with the built frontend + game assets
+#   3. Either runs it as a Docker container OR extracts it for native Node.js use
+#
+# Prerequisites:
+#   - Docker installed
+#   - celeste-wasm.tar at the project root (game assets)
+#   - Optionally: docker-assets/Celeste.exe for automatic patching
+#
+# Usage:
+#   ./scripts/docker-build-server.sh              # Build + run as Docker container
+#   ./scripts/docker-build-server.sh --extract     # Build + extract package for native use
+#   ./scripts/docker-build-server.sh --build-only  # Just build the Docker image
+#   ./scripts/docker-build-server.sh --help        # Show this help
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+IMAGE_NAME="celeste-wasm-server"
+CONTAINER_PORT=8080
+HOST_PORT=8080
+EXTRACT_DIR="$PROJECT_ROOT/celeste-wasm-server"
+
+# Parse arguments
+ACTION="run"
+for arg in "$@"; do
+    case $arg in
+        --extract)
+            ACTION="extract"
+            ;;
+        --build-only)
+            ACTION="build-only"
+            ;;
+        --port=*)
+            HOST_PORT="${arg#*=}"
+            ;;
+        --help|-h)
+            echo ""
+            echo "  celeste-wasm server builder"
+            echo "  ---------------------------"
+            echo ""
+            echo "  Usage: $0 [options]"
+            echo ""
+            echo "  Options:"
+            echo "    --extract       Build and extract package to celeste-wasm-server/"
+            echo "                    (for running natively with 'node server.mjs')"
+            echo "    --build-only    Just build the Docker image, don't run or extract"
+            echo "    --port=PORT     Host port to bind when running (default: 8080)"
+            echo "    --help, -h      Show this help"
+            echo ""
+            echo "  Default (no flags): Build the image and run the container on port $HOST_PORT"
+            echo ""
+            echo "  Prerequisites:"
+            echo "    - celeste-wasm.tar must exist at the project root"
+            echo "    - Optionally place Celeste.exe in docker-assets/ for auto-patching"
+            echo ""
+            exit 0
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+# ---------------------------------------------------------------------------
+# Validate prerequisites
+# ---------------------------------------------------------------------------
+echo ""
+echo "  celeste-wasm server builder"
+echo "  ---------------------------"
+echo ""
+
+if [ ! -f "celeste-wasm.tar" ]; then
+    echo "  Error: celeste-wasm.tar not found at project root."
+    echo "  This file contains the game assets (Content/, CustomCeleste.dll, etc.)"
+    exit 1
+fi
+
+# Ensure docker-assets directory exists (even if empty — Dockerfile COPY needs it)
+if [ ! -d "docker-assets" ]; then
+    echo "  Note: docker-assets/ not found, creating empty directory."
+    echo "  (Place Celeste.exe there for automatic patching)"
+    mkdir -p docker-assets
+fi
+
+# ---------------------------------------------------------------------------
+# Build the Docker image
+# ---------------------------------------------------------------------------
+echo "  Building Docker image (this may take a while on first run)..."
+echo "  Platform: linux/amd64 (required for emsdk)"
+echo ""
+
+docker build \
+    --platform linux/amd64 \
+    -f Dockerfile.server \
+    -t "$IMAGE_NAME:latest" \
+    .
+
+echo ""
+echo "  Docker image built successfully: $IMAGE_NAME:latest"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Action: run, extract, or build-only
+# ---------------------------------------------------------------------------
+case $ACTION in
+    build-only)
+        echo "  Image ready. You can run it with:"
+        echo "    docker run -p $HOST_PORT:8080 $IMAGE_NAME"
+        echo ""
+        echo "  Or extract the package with:"
+        echo "    $0 --extract"
+        ;;
+
+    extract)
+        echo "  Extracting server package to $EXTRACT_DIR..."
+        rm -rf "$EXTRACT_DIR"
+
+        # Create a temporary container and copy files out
+        docker create --name celeste-wasm-tmp "$IMAGE_NAME:latest" > /dev/null 2>&1
+        docker cp celeste-wasm-tmp:/app "$EXTRACT_DIR"
+        docker rm celeste-wasm-tmp > /dev/null 2>&1
+
+        echo ""
+        echo "  Package extracted to: celeste-wasm-server/"
+        echo ""
+        echo "  To run (requires Node.js):"
+        echo "    cd celeste-wasm-server"
+        echo "    node server.mjs"
+        echo ""
+        echo "  Options:"
+        echo "    node server.mjs --port 9000       # custom port"
+        echo "    node server.mjs --no-open         # don't auto-open browser"
+        echo "    node server.mjs --help            # all options"
+        echo ""
+        ;;
+
+    run)
+        echo "  Starting server on port $HOST_PORT..."
+        echo ""
+        echo "  Local:   http://localhost:$HOST_PORT"
+        echo ""
+        echo "  Press Ctrl+C to stop."
+        echo ""
+
+        docker run --rm \
+            -p "$HOST_PORT:8080" \
+            --name celeste-wasm-server \
+            "$IMAGE_NAME:latest"
+        ;;
+esac

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -1,0 +1,451 @@
+#!/usr/bin/env node
+
+// celeste-wasm self-hosted server
+// Zero external dependencies — uses only Node.js built-ins
+// Usage: node server.mjs [--port 8080] [--host 0.0.0.0] [--no-open]
+
+import { createServer } from "node:http";
+import { stat, access, mkdir, writeFile } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { join, extname, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+import { networkInterfaces } from "node:os";
+
+// ---------------------------------------------------------------------------
+// Paths — everything is relative to this script's location
+// ---------------------------------------------------------------------------
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const DIST_DIR = resolve(__dirname, "dist");
+const TAR_FILE = resolve(__dirname, "celeste-wasm.tar");
+const CACHE_DIR = resolve(__dirname, "cache");
+const CACHE_MARKER = join(CACHE_DIR, ".extracted");
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing (minimal, no deps)
+// ---------------------------------------------------------------------------
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = { port: 8080, host: "0.0.0.0", open: true };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--port":
+      case "-p":
+        opts.port = parseInt(args[++i], 10);
+        break;
+      case "--host":
+        opts.host = args[++i];
+        break;
+      case "--no-open":
+        opts.open = false;
+        break;
+      case "--help":
+        console.log(`
+celeste-wasm server
+
+Usage: node server.mjs [options]
+
+Options:
+  --port, -p <number>   Port to listen on (default: 8080)
+  --host <string>       Host to bind to (default: 0.0.0.0)
+  --no-open             Don't auto-open the browser
+  --help                Show this help
+`);
+        process.exit(0);
+    }
+  }
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// MIME types
+// ---------------------------------------------------------------------------
+const MIME_TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".htm": "text/html; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".wasm": "application/wasm",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".ttf": "font/ttf",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".otf": "font/otf",
+  ".xml": "application/xml",
+  ".txt": "text/plain; charset=utf-8",
+  ".bin": "application/octet-stream",
+  ".dll": "application/octet-stream",
+  ".exe": "application/octet-stream",
+  ".pdb": "application/octet-stream",
+  ".dat": "application/octet-stream",
+  ".xnb": "application/octet-stream",
+  ".ogg": "audio/ogg",
+  ".bank": "application/octet-stream",
+  ".obj": "text/plain",
+  ".export": "text/plain",
+  ".spritefont": "application/xml",
+  ".celeste": "application/octet-stream",
+  ".tar": "application/x-tar",
+  ".zip": "application/zip",
+};
+
+function getMimeType(filePath) {
+  const ext = extname(filePath).toLowerCase();
+  return MIME_TYPES[ext] || "application/octet-stream";
+}
+
+// ---------------------------------------------------------------------------
+// Tar extraction — uses system `tar` command
+// ---------------------------------------------------------------------------
+async function extractTarIfNeeded() {
+  // Check if already extracted
+  try {
+    await access(CACHE_MARKER);
+    console.log("  Game assets already extracted (cached).");
+    return;
+  } catch {
+    // Not extracted yet
+  }
+
+  // Check tar file exists
+  try {
+    await access(TAR_FILE);
+  } catch {
+    console.error(`  Error: ${TAR_FILE} not found.`);
+    console.error("  Place celeste-wasm.tar next to server.mjs");
+    process.exit(1);
+  }
+
+  console.log("  Extracting game assets (first run only)...");
+  const startTime = Date.now();
+
+  await mkdir(CACHE_DIR, { recursive: true });
+
+  try {
+    execSync(`tar xf "${TAR_FILE}" -C "${CACHE_DIR}"`, {
+      stdio: "pipe",
+      timeout: 300_000, // 5 min timeout
+    });
+  } catch (err) {
+    console.error("  Failed to extract tar:", err.message);
+    process.exit(1);
+  }
+
+  // Create bundled marker inside content directory
+  const contentDir = join(CACHE_DIR, "Content");
+  try {
+    await access(contentDir);
+    await writeFile(join(contentDir, ".bundled"), "");
+  } catch {
+    console.warn(
+      "  Warning: Content/ directory not found in tar -- game may not work correctly"
+    );
+  }
+
+  // Write extraction marker
+  await writeFile(CACHE_MARKER, new Date().toISOString());
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log(`  Extracted game assets in ${elapsed}s`);
+}
+
+// ---------------------------------------------------------------------------
+// Check that dist/ directory exists
+// ---------------------------------------------------------------------------
+async function checkDist() {
+  try {
+    await access(DIST_DIR);
+  } catch {
+    console.error(`  Error: ${DIST_DIR} not found.`);
+    console.error(
+      '  Build the frontend first with "make publish", then copy frontend/dist/ here.'
+    );
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Resolve a URL path to a file on disk
+// ---------------------------------------------------------------------------
+// Route mapping:
+//   /content/.bundled   -> virtual 200 OK
+//   /content/*          -> cache/Content/*
+//   /CustomCeleste.dll  -> cache/CustomCeleste.dll
+//   /Celeste.exe        -> cache/Celeste.exe
+//   /_framework/*       -> dist/_framework/*
+//   /*                  -> dist/*
+//   fallback            -> dist/index.html (SPA)
+
+// Files from tar root that should be served at HTTP root
+const CACHE_ROOT_FILES = new Set([
+  "CustomCeleste.dll",
+  "Celeste.exe",
+  "MMHOOK_Celeste.dll",
+  "Celeste.Mod.mm.dll",
+  ".ContentExists",
+]);
+
+async function resolveFile(urlPath) {
+  // Prevent directory traversal
+  const sanitized = urlPath.replace(/\.\./g, "").replace(/\/+/g, "/");
+
+  // Virtual: /content/.bundled always returns 200
+  if (sanitized === "/content/.bundled") {
+    return { virtual: true, body: "", mime: "text/plain" };
+  }
+
+  // /content/* -> cache/Content/*
+  if (sanitized.startsWith("/content/")) {
+    const subPath = sanitized.slice("/content/".length);
+    const filePath = join(CACHE_DIR, "Content", subPath);
+    return { filePath };
+  }
+
+  // Root-level game files -> cache/
+  const baseName = sanitized.slice(1); // strip leading /
+  if (CACHE_ROOT_FILES.has(baseName)) {
+    const filePath = join(CACHE_DIR, baseName);
+    return { filePath };
+  }
+
+  // Everything else -> dist/
+  let filePath = join(DIST_DIR, sanitized);
+
+  try {
+    const s = await stat(filePath);
+    if (s.isDirectory()) {
+      filePath = join(filePath, "index.html");
+    }
+  } catch {
+    // File doesn't exist in dist — check if it actually exists before SPA fallback
+    // Don't fallback for requests to _framework/ or assets/ (those are real 404s)
+    if (
+      sanitized.startsWith("/_framework/") ||
+      sanitized.startsWith("/assets/")
+    ) {
+      return { filePath }; // Let it 404 naturally
+    }
+    // SPA fallback for everything else
+    filePath = join(DIST_DIR, "index.html");
+  }
+
+  return { filePath };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP request handler
+// ---------------------------------------------------------------------------
+async function handleRequest(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  let urlPath = decodeURIComponent(url.pathname);
+
+  // Normalize: strip trailing slash except for root
+  if (urlPath !== "/" && urlPath.endsWith("/")) {
+    urlPath = urlPath.slice(0, -1);
+  }
+
+  // Root -> /index.html
+  if (urlPath === "/") {
+    urlPath = "/index.html";
+  }
+
+  // Required headers for SharedArrayBuffer (WASM threads)
+  res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+  res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+
+  // CORS for content paths
+  if (urlPath.startsWith("/content/")) {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
+  }
+
+  // Handle OPTIONS preflight
+  if (req.method === "OPTIONS") {
+    res.setHeader("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "*");
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  try {
+    const resolved = await resolveFile(urlPath);
+
+    // Virtual responses (e.g., /content/.bundled)
+    if (resolved.virtual) {
+      res.setHeader("Content-Type", resolved.mime);
+      res.writeHead(200);
+      res.end(resolved.body);
+      return;
+    }
+
+    const filePath = resolved.filePath;
+
+    // Check the file exists and get its size
+    let fileStat;
+    try {
+      fileStat = await stat(filePath);
+    } catch {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Not Found");
+      return;
+    }
+
+    if (!fileStat.isFile()) {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Not Found");
+      return;
+    }
+
+    const mime = getMimeType(filePath);
+    const size = fileStat.size;
+
+    // Support Range requests (the .NET WASM runtime may use them)
+    const rangeHeader = req.headers.range;
+    if (rangeHeader) {
+      const match = rangeHeader.match(/bytes=(\d+)-(\d*)/);
+      if (match) {
+        const start = parseInt(match[1], 10);
+        const end = match[2] ? parseInt(match[2], 10) : size - 1;
+
+        if (start >= size || end >= size) {
+          res.writeHead(416, {
+            "Content-Range": `bytes */${size}`,
+          });
+          res.end();
+          return;
+        }
+
+        res.writeHead(206, {
+          "Content-Type": mime,
+          "Content-Length": end - start + 1,
+          "Content-Range": `bytes ${start}-${end}/${size}`,
+          "Accept-Ranges": "bytes",
+          "Cache-Control": "public, max-age=3600",
+        });
+
+        if (req.method === "HEAD") {
+          res.end();
+          return;
+        }
+
+        createReadStream(filePath, { start, end }).pipe(res);
+        return;
+      }
+    }
+
+    // Normal response
+    res.writeHead(200, {
+      "Content-Type": mime,
+      "Content-Length": size,
+      "Accept-Ranges": "bytes",
+      "Cache-Control": "public, max-age=3600",
+    });
+
+    if (req.method === "HEAD") {
+      res.end();
+      return;
+    }
+
+    createReadStream(filePath).pipe(res);
+  } catch (err) {
+    console.error(`  Error serving ${urlPath}:`, err.message);
+    res.writeHead(500, { "Content-Type": "text/plain" });
+    res.end("Internal Server Error");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Get local network IP
+// ---------------------------------------------------------------------------
+function getLocalIP() {
+  const nets = networkInterfaces();
+  for (const name of Object.keys(nets)) {
+    for (const net of nets[name]) {
+      if (net.family === "IPv4" && !net.internal) {
+        return net.address;
+      }
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Open browser
+// ---------------------------------------------------------------------------
+function openBrowser(url) {
+  const platform = process.platform;
+  try {
+    if (platform === "darwin") {
+      execSync(`open "${url}"`, { stdio: "ignore" });
+    } else if (platform === "win32") {
+      execSync(`start "" "${url}"`, { stdio: "ignore" });
+    } else {
+      execSync(
+        `xdg-open "${url}" 2>/dev/null || sensible-browser "${url}" 2>/dev/null`,
+        { stdio: "ignore" }
+      );
+    }
+  } catch {
+    // Silently fail — user can open the URL manually
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  const opts = parseArgs();
+
+  console.log("");
+  console.log("  celeste-wasm server");
+  console.log("  -------------------");
+  console.log("");
+
+  await checkDist();
+  await extractTarIfNeeded();
+
+  console.log("");
+
+  const server = createServer(handleRequest);
+
+  server.listen(opts.port, opts.host, () => {
+    const localUrl = `http://localhost:${opts.port}`;
+    const lanIP = getLocalIP();
+    const networkUrl = lanIP ? `http://${lanIP}:${opts.port}` : null;
+
+    console.log(`  Local:   ${localUrl}`);
+    if (networkUrl) {
+      console.log(`  Network: ${networkUrl}`);
+    }
+    console.log("");
+    console.log("  Press Ctrl+C to stop.");
+    console.log("");
+
+    if (opts.open) {
+      openBrowser(localUrl);
+    }
+  });
+
+  server.on("error", (err) => {
+    if (err.code === "EADDRINUSE") {
+      console.error(`  Error: Port ${opts.port} is already in use.`);
+      console.error(`  Try: node server.mjs --port ${opts.port + 1}`);
+      process.exit(1);
+    }
+    throw err;
+  });
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add a zero-dependency Node.js HTTP server for self-hosting celeste-wasm on a local network
- Add a Dockerfile that builds the frontend inside Docker and produces a ready-to-run image
- No need to extract/organize game files manually — just `docker run` or `node server.mjs`

## How

### Implementation

**`server/server.mjs`** — Static file server using only Node.js built-ins (~450 lines, zero external deps):
- Extracts `celeste-wasm.tar` to a cache dir on first run (uses system `tar`)
- Serves `dist/` (frontend) + `cache/Content/` (game assets) with correct route mapping
- Sets required `Cross-Origin-Embedder-Policy` / `Cross-Origin-Opener-Policy` headers for SharedArrayBuffer
- Range request support, CORS for `/content/`, proper MIME types (`.wasm`, `.dll`, `.bank`, etc.)
- Virtual `/content/.bundled` endpoint so the frontend detects HTTP-bundled mode
- CLI flags: `--port`, `--host`, `--no-open`, `--help`
- Auto-opens browser, prints local + LAN IP

**`Dockerfile.server`** — Multi-stage Docker build:
- Stage 1: Builds frontend with dotnet SDK + emsdk + pnpm (pins pnpm@9 to avoid build script blocking)
- Stage 2: Assembles server package (dist/ + server.mjs + celeste-wasm.tar)
- Stage 3: Minimal `node:22-slim` runtime image
- Fixes NLua `_SignAssembly` target that fails on Linux (rewrites `NLua.Sign.targets` after `make deps` clones it)

**`scripts/docker-build-server.sh`** — One-command wrapper with 3 modes:
- Default: build + run as container on port 8080
- `--extract`: build + copy package out for native Node.js use
- `--build-only`: just build the image

### How to test

```bash
# Option A: Run as Docker container
./scripts/docker-build-server.sh
# -> opens http://localhost:8080

# Option B: Extract for native use
./scripts/docker-build-server.sh --extract
cd celeste-wasm-server && node server.mjs

# Option C: Make targets
make docker-server          # build + run
make docker-server-extract  # build + extract
```

Prerequisites: `celeste-wasm.tar` at project root, optionally `docker-assets/Celeste.exe` for auto-patching.